### PR TITLE
Support for Blob field.

### DIFF
--- a/Source/Neon.Core.Persistence.JSON.pas
+++ b/Source/Neon.Core.Persistence.JSON.pas
@@ -1120,8 +1120,14 @@ begin
       LJSONField := LJSONItem.GetValue(LName);
       if Assigned(LJSONField) then
       begin
-        { TODO -opaolo -c : Be more specific (field and json type) 27/04/2017 17:16:09 }
-        LDataSet.FieldByName(LName).AsString := LJSONField.Value;
+        case LDataSet.Fields[LItemIntex].DataType of
+          ftBlob: TDataSetUtils.Base64ToBlobField(LJSONField.Value, LDataSet.Fields[LItemIntex] as TBlobField);
+        else
+          begin
+            { TODO -opaolo -c : Be more specific (field and json type) 27/04/2017 17:16:09 }
+            LDataSet.FieldByName(LName).AsString := LJSONField.Value;
+          end;
+        end;
       end;
     end;
     LDataSet.Post;

--- a/Source/Neon.Core.Persistence.JSON.pas
+++ b/Source/Neon.Core.Persistence.JSON.pas
@@ -236,6 +236,7 @@ type
     constructor Create(const AConfig: INeonConfiguration);
 
     procedure JSONToObject(AObject: TObject; AJSON: TJSONValue);
+    procedure JSONToDataSet(AJSON: TJSONValue; ADataSet: TDataSet);
     function JSONToTValue(AJSON: TJSONValue; AType: TRttiType): TValue; overload;
     function JSONToTValue(AJSON: TJSONValue; AType: TRttiType; const AData: TValue): TValue; overload;
     function JSONToArray(AJSON: TJSONValue; AType: TRttiType): TValue;
@@ -1121,6 +1122,7 @@ begin
       if Assigned(LJSONField) then
       begin
         case LDataSet.Fields[LItemIntex].DataType of
+          ftDataSet:  JSONToDataSet(LJSONField, (LDataSet.Fields[LItemIntex] as TDataSetField).NestedDataSet);
           ftBlob: TDataSetUtils.Base64ToBlobField(LJSONField.Value, LDataSet.Fields[LItemIntex] as TBlobField);
         else
           begin
@@ -1447,6 +1449,12 @@ end;
 function TNeonDeserializerJSON.JSONToArray(AJSON: TJSONValue; AType: TRttiType): TValue;
 begin
   Result := ReadDataMember(AJSON, AType, TValue.Empty);
+end;
+
+procedure TNeonDeserializerJSON.JSONToDataSet(AJSON: TJSONValue;
+  ADataSet: TDataSet);
+begin
+  ReadDataMember(AJSON, TRttiUtils.Context.GetType(ADataSet.ClassType), ADataSet);
 end;
 
 procedure TNeonDeserializerJSON.JSONToObject(AObject: TObject; AJSON: TJSONValue);

--- a/Source/Neon.Core.Utils.pas
+++ b/Source/Neon.Core.Utils.pas
@@ -148,6 +148,9 @@ type
     class function DataSetToCSV(const ADataSet: TDataSet; AConfig: TNeonConfiguration): string; static;
 
     class function DatasetMetadataToJSONObject(const ADataSet: TDataSet; AConfig: TNeonConfiguration): TJSONObject; static;
+
+    class function BlobFieldToBase64(ABlobField: TBlobField): string;
+    class procedure Base64ToBlobField(const ABase64: string; ABlobField: TBlobField);
   end;
 
 type
@@ -308,7 +311,7 @@ begin
 //        ftBytes: ;
 //        ftVarBytes: ;
       TFieldType.ftAutoInc:       Result.AddPair(LPairName, TJSONNumber.Create(LField.AsInteger));
-//        ftBlob: ;
+      TFieldType.ftBlob:          Result.AddPair(LPairName, BlobFieldToBase64(LField as TBlobField));
       TFieldType.ftMemo:          Result.AddPair(LPairName, LField.AsString);
 //        ftGraphic: ;
 //        ftFmtMemo: ;
@@ -613,6 +616,34 @@ begin
     end;
   finally
     ADataSet.EnableControls;
+  end;
+end;
+
+class procedure TDataSetUtils.Base64ToBlobField(const ABase64: string;
+  ABlobField: TBlobField);
+var
+  LBinaryStream: TMemoryStream;
+begin
+  LBinaryStream := TMemoryStream.Create;
+  try
+    TBase64.Decode(ABase64, LBinaryStream);
+    ABlobField.LoadFromStream(LBinaryStream);
+  finally
+    LBinaryStream.Free;
+  end;
+end;
+
+class function TDataSetUtils.BlobFieldToBase64(ABlobField: TBlobField): string;
+var
+  LBlobStream: TMemoryStream;
+begin
+  LBlobStream := TMemoryStream.Create;
+  try
+    ABlobField.SaveToStream(LBlobStream);
+    LBlobStream.Position := soFromBeginning;
+    Result := TBase64.Encode(LBlobStream);
+  finally
+    LBlobStream.Free;
   end;
 end;
 


### PR DESCRIPTION
Add the functions in TDataSetUtils for encode the blob binary content to Base64 and viceversa (decode from Base64 to binary).
Add the statement in ReadDataSet of TNeonDeserializerJSON in order to handle the blob field.

I think that the Base64 is the best choice for binary data in JSON  (in spite of the overhead of 33%).