### PR TITLE
if not using the option "PrettyPrint" then write only once the Result

### DIFF
--- a/Source/Neon.Core.Persistence.JSON.pas
+++ b/Source/Neon.Core.Persistence.JSON.pas
@@ -1604,7 +1604,10 @@ var
 
 begin
   if not APretty then
+  begin
     AWriter.Write(AJSONValue.ToJSON);
+    exit;
+  end;
 
   LOffset := 0;
   LOutsideString := True;


### PR DESCRIPTION
When you're using the function "TNeon.ObjectToJSONString(obj)" without any configs you'll get the unexpected Result:
`{"Name":"Max Mustermann","Age":41}{
  "Name": "Max Mustermann",
  "Age": 41
}`