### PR TITLE
Normalize line breaks for test file

### DIFF
--- a/Tests/Source/Neon.Tests.Types.Reference.pas
+++ b/Tests/Source/Neon.Tests.Types.Reference.pas
@@ -112,10 +112,14 @@ begin
 end;
 
 procedure TTestReferenceTypes.TestPersonPretty(const AMethod: string);
+var
+	expected, actual: String;
 begin
-  Assert.AreEqual(
-    TTestUtils.ExpectedFromFile(GetFileName(AMethod)),
-    TTestUtils.SerializeObject(FPerson1, TNeonConfiguration.Pretty));
+  expected := TTestUtils.ExpectedFromFile(GetFileName(AMethod));
+  expected := AdjustLineBreaks(expected, TTextLineBreakStyle.tlbsCRLF);
+
+  actual := TTestUtils.SerializeObject(FPerson1, TNeonConfiguration.Pretty);
+  Assert.AreEqual(expected, actual);
 end;
 
 procedure TTestReferenceTypes.TestPersonUnicode(const AMethod: string);

--- a/Tests/Source/Neon.Tests.Types.Reference.pas
+++ b/Tests/Source/Neon.Tests.Types.Reference.pas
@@ -113,7 +113,7 @@ end;
 
 procedure TTestReferenceTypes.TestPersonPretty(const AMethod: string);
 var
-	expected, actual: String;
+  expected, actual: String;
 begin
   expected := TTestUtils.ExpectedFromFile(GetFileName(AMethod));
   expected := AdjustLineBreaks(expected, TTextLineBreakStyle.tlbsCRLF);


### PR DESCRIPTION
Depending on how the file was checked out, it will just contain a LF character, instead of the Windows default CR LF that Neon will use. Comparing this to the produced result of `TTestUtils.SerializeObject(..)` will fail the test.

I propose the file content should be normalized with System.SysUtils.AdjustLineBreaks(..) before comparing with the result. This way, the test will not fail depending on your local git settings.