### PR TITLE
Fixes: Fix: TNeonRttiMember.SetValue, TNeonDeserializerJSON.ReadDataMember, TDynamicStream.LoadFromStream and TDynamicStream.SaveToStream

### DIFF
--- a/Source/Neon.Core.DynamicTypes.pas
+++ b/Source/Neon.Core.DynamicTypes.pas
@@ -208,6 +208,7 @@ class function TDynamicStream.GuessType(AInstance: TObject): IDynamicStream;
 var
   LType: TRttiType;
   LLoadMethod, LSaveMethod: TRttiMethod;
+  LParameters: TArray<TRttiParameter>;
 begin
   if not Assigned(AInstance) then
     Exit(nil);
@@ -218,11 +219,23 @@ begin
     Exit(nil);
 
   LLoadMethod := LType.GetMethod('LoadFromStream');
-  if not Assigned(LLoadMethod) then
+  if Assigned(LLoadMethod) then
+  begin
+    LParameters := LLoadMethod.GetParameters;
+    if Length(LParameters) <> 1 then
+      Exit(nil);
+  end
+  else
     Exit(nil);
 
   LSaveMethod := LType.GetMethod('SaveToStream');
-  if not Assigned(LSaveMethod) then
+  if Assigned(LSaveMethod) then
+  begin
+    LParameters := LSaveMethod.GetParameters;
+    if Length(LParameters) <> 1 then
+      Exit(nil);
+  end
+  else
     Exit(nil);
 
   Result := Self.Create(AInstance, LLoadMethod, LSaveMethod);

--- a/Source/Neon.Core.Persistence.JSON.pas
+++ b/Source/Neon.Core.Persistence.JSON.pas
@@ -1094,9 +1094,6 @@ function TNeonDeserializerJSON.ReadDataMember(const AParam: TNeonDeserializerPar
 var
   LCustom: TCustomSerializer;
 begin
-  if AParam.JSONValue is TJSONNull then
-    Exit(TValue.Empty);
-
   // if there is a custom serializer
   LCustom := FConfig.Serializers.GetSerializer(AParam.RttiType.Handle);
 
@@ -1104,6 +1101,11 @@ begin
   begin
     Result := LCustom.Deserialize(AParam.JSONValue, AData, AParam.NeonObject, Self);
     Exit(Result);
+  end
+  else
+  begin
+    if AParam.JSONValue is TJSONNull then
+      Exit(TValue.Empty);
   end;
 
   case AParam.RttiType.TypeKind of
@@ -1676,15 +1678,15 @@ var
   end;
 
 begin
+  LJSONString := AJSONValue.ToJSON;
   if not APretty then
   begin
-    AWriter.Write(AJSONValue.ToJSON);
+    AWriter.Write(LJSONString);
     Exit;
   end;
 
   LOffset := 0;
   LOutsideString := True;
-  LJSONString := AJSONValue.ToJSON;
 
   for LIndex := 0 to Length(LJSONString) - 1 do
   begin

--- a/Source/Neon.Core.Persistence.pas
+++ b/Source/Neon.Core.Persistence.pas
@@ -661,7 +661,11 @@ end;
 procedure TNeonRttiMember.SetValue(const AValue: TValue);
 begin
   case FMemberType of
-    TNeonMemberType.Prop : MemberAsProperty.SetValue(FParent.Instance, AValue);
+    TNeonMemberType.Prop :
+    begin
+      if MemberAsProperty.IsWritable then
+        MemberAsProperty.SetValue(FParent.Instance, AValue);
+    end;
     TNeonMemberType.Field: MemberAsField.SetValue(FParent.Instance, AValue);
   end;
 end;


### PR DESCRIPTION
Fix: TNeonRttiMember.SetValue only if MemberAsProperty.IsWritable
Fix: TNeonDeserializerJSON.ReadDataMember checks for Custom Serializers before returning TValue.Empty
Fix: TDynamicStream.LoadFromStream and TDynamicStream.SaveToStream invoked only if exists a method with a single parameter.