### PR TITLE
Add configuration option EnumAsInt.

### DIFF
--- a/Source/Neon.Core.Persistence.pas
+++ b/Source/Neon.Core.Persistence.pas
@@ -47,6 +47,7 @@ type
     function SetUseUTCDate(AValue: Boolean): INeonConfiguration;
     function SetRaiseExceptions(AValue: Boolean): INeonConfiguration;
     function SetPrettyPrint(AValue: Boolean): INeonConfiguration;
+    function SetEnumAsInt(AValue: Boolean): INeonConfiguration;
 
     function GetPrettyPrint: Boolean;
     function GetUseUTCDate: Boolean;
@@ -173,6 +174,7 @@ type
     FPrettyPrint: Boolean;
     FSerializers: TNeonSerializerRegistry;
     FRaiseExceptions: Boolean;
+    FEnumAsInt: Boolean;
   public
     constructor Create;
     destructor Destroy; override;
@@ -190,6 +192,7 @@ type
     function SetUseUTCDate(AValue: Boolean): INeonConfiguration;
     function SetRaiseExceptions(AValue: Boolean): INeonConfiguration;
     function SetPrettyPrint(AValue: Boolean): INeonConfiguration;
+    function SetEnumAsInt(AValue: Boolean): INeonConfiguration;
 
     function GetUseUTCDate: Boolean;
     function GetPrettyPrint: Boolean;
@@ -203,6 +206,7 @@ type
     property IgnoreFieldPrefix: Boolean read FIgnoreFieldPrefix write FIgnoreFieldPrefix;
     property UseUTCDate: Boolean read FUseUTCDate write FUseUTCDate;
     property RaiseExceptions: Boolean read FRaiseExceptions write FRaiseExceptions;
+    property EnumAsInt: Boolean read FEnumAsInt write FEnumAsInt;
     property Serializers: TNeonSerializerRegistry read FSerializers write FSerializers;
   end;
 
@@ -552,6 +556,12 @@ function TNeonConfiguration.SetUseUTCDate(AValue: Boolean): INeonConfiguration;
 begin
   FUseUTCDate := AValue;
   Result := Self;
+end;
+
+function TNeonConfiguration.SetEnumAsInt(AValue: Boolean): INeonConfiguration;
+begin
+  FEnumAsInt := AValue;
+  result := Self;
 end;
 
 function TNeonConfiguration.SetIgnoreFieldPrefix(AValue: Boolean): INeonConfiguration;

--- a/Tests/Neon.Tests.Framework.dpr
+++ b/Tests/Neon.Tests.Framework.dpr
@@ -47,7 +47,8 @@ uses
   Neon.Tests.Types.Records in 'Source\Neon.Tests.Types.Records.pas',
   Neon.Tests.Types.Reference in 'Source\Neon.Tests.Types.Reference.pas',
   Neon.Tests.CustomSerializers in 'Source\Neon.Tests.CustomSerializers.pas',
-  Neon.Tests.Config.MemberCase in 'Source\Neon.Tests.Config.MemberCase.pas';
+  Neon.Tests.Config.MemberCase in 'Source\Neon.Tests.Config.MemberCase.pas',
+  Neon.Tests.Config.EnumAsInt in 'Source\Neon.Tests.Config.EnumAsInt.pas';
 
 var
   LRunner : ITestRunner;

--- a/Tests/Neon.Tests.Framework.dproj
+++ b/Tests/Neon.Tests.Framework.dproj
@@ -106,6 +106,7 @@
         <DCCReference Include="Source\Neon.Tests.Types.Reference.pas"/>
         <DCCReference Include="Source\Neon.Tests.CustomSerializers.pas"/>
         <DCCReference Include="Source\Neon.Tests.Config.MemberCase.pas"/>
+        <DCCReference Include="Source\Neon.Tests.Config.EnumAsInt.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
         </BuildConfiguration>

--- a/Tests/Source/Neon.Tests.Config.EnumAsInt.pas
+++ b/Tests/Source/Neon.Tests.Config.EnumAsInt.pas
@@ -1,0 +1,80 @@
+unit Neon.Tests.Config.EnumAsInt;
+
+interface
+
+uses
+  System.Classes, DUnitX.TestFramework,
+
+  Neon.Core.Types;
+
+type
+  [TestFixture]
+  [Category('enumasint')]
+  TTestConfigEnumAsInt = class(TObject)
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    [TestCase('TestTDuplicates', '1,dupAccept')]
+    procedure TestDeserialize(const AValue: String; _Result: TDuplicates);
+
+    [Test]
+    [TestCase('TestTDuplicates', 'dupAccept,1')]
+    procedure TestSerialize(const AValue: TDuplicates; _Result: string);
+
+    [Test]
+    [TestCase('TestTDuplicates', '3,dupAccept')]
+    [TestCase('TestTDuplicates', '-1,dupError')]
+    procedure TestReadOutOfBounds(const AValue: String; _Result: TDuplicates);
+
+  end;
+
+implementation
+
+uses
+  System.Rtti, Neon.Tests.Utils, Neon.Core.Persistence;
+
+{ TTestConfigEnumAsInt }
+
+procedure TTestConfigEnumAsInt.Setup;
+begin
+end;
+
+procedure TTestConfigEnumAsInt.TearDown;
+begin
+end;
+
+procedure TTestConfigEnumAsInt.TestDeserialize(const AValue: String; _Result: TDuplicates);
+var
+  LConfig: INeonConfiguration;
+begin
+  LConfig := TNeonConfiguration.Default.SetEnumAsInt(True);
+  Assert.AreEqual(_Result, TTestUtils.DeserializeValueTo<TDuplicates>(AValue, lConfig));
+end;
+
+procedure TTestConfigEnumAsInt.TestSerialize(const AValue: TDuplicates; _Result: string);
+var
+  LConfig: INeonConfiguration;
+begin
+  LConfig := TNeonConfiguration.Default.SetEnumAsInt(True);
+  Assert.AreEqual(_Result, TTestUtils.SerializeValue(TValue.From<TDuplicates>(aValue), LConfig));
+end;
+
+procedure TTestConfigEnumAsInt.TestReadOutOfBounds(const AValue: String; _Result: TDuplicates);
+var
+  LConfig: INeonConfiguration;
+begin
+  LConfig := TNeonConfiguration.Default.SetEnumAsInt(True);
+  Assert.WillRaise(
+    procedure begin TTestUtils.DeserializeValueTo<TDuplicates>(AValue, lConfig) end,
+    ENeonException
+  );
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestConfigEnumAsInt);
+
+end.


### PR DESCRIPTION
Sometimes this option is needed when the one side (i.e. the client or the server) cannot be changed.