### PR TITLE
Bugfix memoryleak empty list in dictionary

### DIFF
--- a/Source/Neon.Core.Persistence.JSON.pas
+++ b/Source/Neon.Core.Persistence.JSON.pas
@@ -1321,7 +1321,9 @@ begin
     tkClass:
     begin
       if TJSONUtils.IsNotEmpty(AParam.JSONValue) then
-        Result := ReadReference(AParam, AData);
+        Result := ReadReference(AParam, AData)
+      else
+        Result := AData;
     end;
 
     tkRecord{$IFDEF HAS_MRECORDS}, tkMRecord{$ENDIF}:
@@ -1332,7 +1334,9 @@ begin
           Result := AData
         else
           Result := ReadRecord(AParam, AData);
-      end;
+      end
+      else
+        Result := AData;
     end;
 
   end;

--- a/Source/Neon.Core.Persistence.JSON.pas
+++ b/Source/Neon.Core.Persistence.JSON.pas
@@ -1334,9 +1334,7 @@ begin
           Result := AData
         else
           Result := ReadRecord(AParam, AData);
-      end
-      else
-        Result := AData;
+      end;
     end;
 
   end;


### PR DESCRIPTION
When there is a TObjectList in a TObjectDictionary and the list is empty in the json then the list is nil in the dictionary even though it was created.
It would be better if the dictionary would keep the reference and be able to free it.

```pascal
TRoot = class
private
  FDictionary : TObjectDictionary<String, TObjectList<TItem>>;
public
  property Dictionary : TObjectDictionary<String, TObjectList<TItem>> read FDictionary write FDictionary;
end;
```

#### Original JSON
```json
{"dictionary":{"list1":[{"a":"","b":""}],"list2":[]}}
```

#### After Serialization/Deserialization --> Memoryleak list2
```json
{"dictionary":{"list1":[{"a":"","b":""}]}}
```

#### Optimization --> No Memoryleak
```json
{"dictionary":{"list1":[{"a":"","b":""}],"list2":[]}}
```
