### PR TITLE
fix for JSON encoding of streams

### DIFF
--- a/Source/Neon.Core.Utils.pas
+++ b/Source/Neon.Core.Utils.pas
@@ -967,8 +967,15 @@ begin
 {$IFDEF HAS_NET_ENCODING}
   LBase64Stream := TStringStream.Create;
   try
-    TNetEncoding.Base64.Encode(ASource, LBase64Stream);
-    Result := LBase64Stream.DataString;
+    // FIX: if CharsPerLine is not initialized, it adds \r\n line feeds to
+    //      each line that are not part of Base64
+    var LEncoder := TBase64Encoding.Create(0);
+    try
+      LEncoder.Encode(ASource, LBase64Stream);
+      Result := LBase64Stream.DataString;
+    finally
+      LEncoder.Free;
+    end;
   finally
     LBase64Stream.Free;
   end;


### PR DESCRIPTION
Base64 encoding is spread across multiple lines in JSON. Line feeds get translated to \r\n which leads to an invalid Base64 encoding when trying to decode this.

The fix creates a custom `TNetEncoding` instance which does not spread the content across multiple lines. This should be reviewed with regards to `PrettyPrint`...