### PR TITLE
Using attribute IncludeIf.NotEmpty for TBytes

### DIFF
--- a/Source/Neon.Core.Serializers.RTL.pas
+++ b/Source/Neon.Core.Serializers.RTL.pas
@@ -387,6 +387,15 @@ begin
   LVal := AValue.AsType<TBytes>;
   LFormat := ANeonObject.GetAttribute<NeonFormatAttribute>;
 
+  if Length(LVal) = 0 then
+  begin
+    case ANeonObject.NeonInclude.Value of
+      IncludeIf.NotEmpty, IncludeIf.NotDefault: Exit(nil);
+    else
+      Exit(TJSONString.Create(''));
+    end;
+  end;
+
   if IsFormatValue(LFormat, 'native') then
     Exit(AContext.WriteDataMember(AValue, False));
 


### PR DESCRIPTION
If NeonInclude attribute with param IncludeIf.NotEmpty or IncludeIf.NotDefault is used, and TBytes is Empty, then not produce output field.