### PR TITLE
Add MapSort configuration option with sorting implementation for maps

### DIFF
--- a/Source/Neon.Core.Persistence.JSON.pas
+++ b/Source/Neon.Core.Persistence.JSON.pas
@@ -27,7 +27,8 @@ interface
 
 uses
   System.SysUtils, System.Classes, System.Rtti, System.SyncObjs,
-  System.TypInfo, System.Generics.Collections, System.JSON,
+  System.TypInfo, System.Generics.Collections, System.Generics.Defaults,
+  System.JSON,
 
   Neon.Core.Types,
   Neon.Core.Attributes,
@@ -1023,6 +1024,20 @@ var
   LJSONName: TJSONValue;
   LJSONValue: TJSONValue;
   LKeyValue, LValValue: TValue;
+  LPairs: TObjectList<TJSONPair>;
+  LPair: TJSONPair;
+
+  function PairKeyComparer(AReverse: Boolean): IComparer<TJSONPair>;
+  begin
+    Result := TComparer<TJSONPair>.Construct(
+      function(const ALeft, ARight: TJSONPair): Integer
+      begin
+        Result := CompareStr(ALeft.JsonString.Value, ARight.JsonString.Value);
+        if AReverse then
+          Result := -Result;
+      end);
+  end;
+
 begin
   // Not an EnumerableMap object
   if not Assigned(AMap) then
@@ -1049,27 +1064,44 @@ begin
 
   Result := TJSONObject.Create;
   try
-    while AMap.MoveNext do
-    begin
-      LKeyValue := AMap.CurrentKey;
-      LValValue := AMap.CurrentValue;
+    LPairs := TObjectList<TJSONPair>.Create(True);
+    try
+      while AMap.MoveNext do
+      begin
+        LKeyValue := AMap.CurrentKey;
+        LValValue := AMap.CurrentValue;
 
-      LJSONName := WriteDataMember(LKeyValue);
-      try
-        LJSONValue := WriteDataMember(LValValue);
+        LJSONName := WriteDataMember(LKeyValue);
+        try
+          LJSONValue := WriteDataMember(LValValue);
 
-        if LJSONName is TJSONString then
-          LName := (LJSONName as TJSONString).Value
-        else if AMap.KeyIsString then
-          LName := AMap.KeyToString(LKeyValue);
+          if LJSONName is TJSONString then
+            LName := (LJSONName as TJSONString).Value
+          else if AMap.KeyIsString then
+            LName := AMap.KeyToString(LKeyValue);
 
-        (Result as TJSONObject).AddPair(LName, LJSONValue);
+          LPairs.Add(TJSONPair.Create(LName, LJSONValue));
 
-        if LName.IsEmpty then
-          raise ENeonException.Create(TNeonError.DICT_KEY_INVALID);
-      finally
-        LJSONName.Free;
+          if LName.IsEmpty then
+            raise ENeonException.Create(TNeonError.DICT_KEY_INVALID);
+        finally
+          LJSONName.Free;
+        end;
       end;
+
+      case FConfig.MapSort of
+        TNeonSort.Rtti: ; // Default, keep the map enumeration order
+        TNeonSort.RttiReverse: LPairs.Reverse;
+        TNeonSort.Alpha: LPairs.Sort(PairKeyComparer(False));
+        TNeonSort.AlphaReverse: LPairs.Sort(PairKeyComparer(True));
+      end;
+
+      for LPair in LPairs do
+        (Result as TJSONObject).AddPair(LPair);
+      // The pairs are now owned by the resulting JSON object
+      LPairs.OwnsObjects := False;
+    finally
+      LPairs.Free;
     end;
   except
     on E: Exception do

--- a/Source/Neon.Core.Persistence.pas
+++ b/Source/Neon.Core.Persistence.pas
@@ -216,6 +216,7 @@ type
     // Member-related settings
     function SetMembers(AValue: TNeonMembersSet): INeonConfiguration;
     function SetMemberSort(AValue: TNeonSort): INeonConfiguration;
+    function SetMapSort(AValue: TNeonSort): INeonConfiguration;
     function SetMemberCase(AValue: TNeonCase): INeonConfiguration;
     function SetMemberCustomCase(AValue: TCaseFunc): INeonConfiguration;
     function SetVisibility(AValue: TNeonVisibility): INeonConfiguration;
@@ -284,6 +285,7 @@ type
     FVisibility: TNeonVisibility;
     FMembers: TNeonMembersSet;
     FMemberSort: TNeonSort;
+    FMapSort: TNeonSort;
     FMemberCase: TNeonCase;
     FMemberCustomCase: TCaseFunc;
     FIgnoreFieldPrefix: Boolean;
@@ -313,6 +315,7 @@ type
 
     function SetMembers(AValue: TNeonMembersSet): INeonConfiguration;
     function SetMemberSort(AValue: TNeonSort): INeonConfiguration;
+    function SetMapSort(AValue: TNeonSort): INeonConfiguration;
     function SetMemberCase(AValue: TNeonCase): INeonConfiguration;
     function SetMemberCustomCase(AValue: TCaseFunc): INeonConfiguration;
     function SetVisibility(AValue: TNeonVisibility): INeonConfiguration;
@@ -338,6 +341,7 @@ type
 
     property Members: TNeonMembersSet read FMembers write FMembers;
     property MemberSort: TNeonSort read FMemberSort write FMemberSort;
+    property MapSort: TNeonSort read FMapSort write FMapSort;
     property MemberCase: TNeonCase read FMemberCase write FMemberCase;
     property MemberCustomCase: TCaseFunc read FMemberCustomCase write FMemberCustomCase;
     property Visibility: TNeonVisibility read FVisibility write FVisibility;
@@ -807,6 +811,12 @@ end;
 function TNeonConfiguration.SetMemberSort(AValue: TNeonSort): INeonConfiguration;
 begin
   FMemberSort := AValue;
+  Result := Self;
+end;
+
+function TNeonConfiguration.SetMapSort(AValue: TNeonSort): INeonConfiguration;
+begin
+  FMapSort := AValue;
   Result := Self;
 end;
 

--- a/Tests/Neon.Tests.Framework.dpr
+++ b/Tests/Neon.Tests.Framework.dpr
@@ -53,6 +53,7 @@ uses
   Neon.Tests.Attributes.Factory in 'Source\Neon.Tests.Attributes.Factory.pas',
   Neon.Tests.CustomSerializers in 'Source\Neon.Tests.CustomSerializers.pas',
   Neon.Tests.Config.IgnoreMembers in 'Source\Neon.Tests.Config.IgnoreMembers.pas',
+  Neon.Tests.Config.MapSort in 'Source\Neon.Tests.Config.MapSort.pas',
   Neon.Tests.ConfigTypes in 'Source\Neon.Tests.ConfigTypes.pas';
 
 var

--- a/Tests/Neon.Tests.Framework.dproj
+++ b/Tests/Neon.Tests.Framework.dproj
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{838CCB26-5CA2-48E5-9080-1332A8A77EA2}</ProjectGuid>
-        <ProjectVersion>20.2</ProjectVersion>
+        <ProjectVersion>20.3</ProjectVersion>
         <FrameworkType>None</FrameworkType>
         <MainSource>Neon.Tests.Framework.dpr</MainSource>
         <Base>True</Base>
@@ -125,6 +125,7 @@
         <DCCReference Include="Source\Neon.Tests.Attributes.Factory.pas"/>
         <DCCReference Include="Source\Neon.Tests.CustomSerializers.pas"/>
         <DCCReference Include="Source\Neon.Tests.Config.IgnoreMembers.pas"/>
+        <DCCReference Include="Source\Neon.Tests.Config.MapSort.pas"/>
         <DCCReference Include="Source\Neon.Tests.ConfigTypes.pas"/>
         <BuildConfiguration Include="Base">
             <Key>Base</Key>
@@ -284,6 +285,16 @@
                     </Platform>
                     <Platform Name="Android64">
                         <RemoteDir>res\values-v31</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                </DeployClass>
+                <DeployClass Name="AndroidSplashStylesV35">
+                    <Platform Name="Android">
+                        <RemoteDir>res\values-v35</RemoteDir>
+                        <Operation>1</Operation>
+                    </Platform>
+                    <Platform Name="Android64">
+                        <RemoteDir>res\values-v35</RemoteDir>
                         <Operation>1</Operation>
                     </Platform>
                 </DeployClass>


### PR DESCRIPTION
### What
Adds an opt-in `SetMapSort(TNeonSort)` configuration option. When set to `TNeonSort.Alpha` (or `AlphaReverse`), `TNeonSerializerJSON.WriteEnumerableMap` emits JSON object pairs sorted by key instead of in the dictionary's hash/enumeration order; `RttiReverse` reverses the enumeration order. The default, `TNeonSort.Rtti`, preserves the current behavior — no change for existing users.

### Why
`TDictionary` enumeration order is arbitrary (hash buckets + growth history), so any map serialized by Neon produces JSON whose key order is unpredictable and unstable across mutations. Sorted keys give deterministic, diffable, human-readable output. The motivating case is OpenAPI-Delphi, where `paths`, `components/schemas`, and schema `properties` are all dictionary-backed maps — with this option enabled, generated OpenAPI documents list endpoints and fields alphabetically.

### How
1. **`Neon.Core.Persistence.pas`** — new `FMapSort: TNeonSort` field on `TNeonConfiguration` with a `SetMapSort` fluent setter on `INeonConfiguration` and a `MapSort` property, mirroring how `MemberSort` is implemented. Default `TNeonSort.Rtti`.
2. **`Neon.Core.Persistence.JSON.pas`** — `WriteEnumerableMap` collects the pairs into a `TObjectList<TJSONPair>` first, applies the configured sort, then adds the pairs to the result object. The temporary list owns the pairs until they are transferred, so the existing error paths (invalid empty key, serialization exceptions) free everything correctly — no leaks on failure.

### Compatibility
- Default behavior unchanged (`TNeonSort.Rtti` → enumeration order, same as before).
- Sorting only affects the output order of JSON object members, which is not significant per RFC 8259.
- `System.Generics.Defaults` added to the uses of `Neon.Core.Persistence.JSON.pas` for `TComparer<T>`.

### Tests
New `Neon.Tests.Config.MapSort.pas` (registered in `Neon.Tests.Framework`) serializing a `TDictionary<string, Integer>` with keys inserted in non-alphabetical order:
- `Alpha` → asserts exact key sequence `alpha, mike, zulu`
- `AlphaReverse` → asserts exact key sequence `zulu, mike, alpha`
- default → asserts all pairs present (order unspecified)

Full test suite run (Delphi 12.3, Win64): the 3 new tests pass. 5 pre-existing tests fail identically on unmodified master and are unrelated to this change.